### PR TITLE
Fix for critical error

### DIFF
--- a/gs-blog/class/Blog.php
+++ b/gs-blog/class/Blog.php
@@ -564,7 +564,7 @@ class Blog
 		foreach($post_data as $key => $value)
 		{
 			$parent_nodes_node = $xml->addChild($key);
-				$parent_nodes_node->addCData($value);
+				$parent_nodes_node->addCData(is_array($value)?strval($value[0]):strval($value));
 		}
 		$blog_settings = XMLsave($xml, BLOGSETTINGS);
 		if($blog_settings)


### PR DESCRIPTION
addCData argument must be a string, but on installation it gets language variable that is an array. This causes an error and makes installation impossible